### PR TITLE
Switched md-btn-dropdown boolean attributes to use booleans

### DIFF
--- a/addon/components/md-btn-dropdown.js
+++ b/addon/components/md-btn-dropdown.js
@@ -20,14 +20,13 @@ export default MaterializeButton.extend({
     // needed until the Materialize.dropdown plugin is replaced
     this.$().attr('data-activates', this.get('_dropdownContentId'));
 
-    var that = this;
     this.$().dropdown({
-      hover: this.getWithDefault('hover', false) === 'true',
-      constrainWidth: this.getWithDefault('constrainWidth', true) === 'true',
-      inDuration: this.getWithDefault('inDuration', that.get('_mdSettings.dropdownInDuration')),
-      outDuration: this.getWithDefault('outDuration', that.get('_mdSettings.dropdownOutDuration')),
+      hover: !!this.getWithDefault('hover', false),
+      constrainWidth: !!this.getWithDefault('constrainWidth', true),
+      inDuration: this.getWithDefault('inDuration', this.get('_mdSettings.dropdownInDuration')),
+      outDuration: this.getWithDefault('outDuration', this.get('_mdSettings.dropdownOutDuration')),
       gutter: this.getWithDefault('gutter', 0),
-      belowOrigin: this.getWithDefault('belowOrigin', false) === 'true'
+      belowOrigin: !!this.getWithDefault('belowOrigin', false)
     });
   },
   _dropdownContentId: computed({

--- a/tests/dummy/app/templates/snippets/buttons-dropdown.hbs
+++ b/tests/dummy/app/templates/snippets/buttons-dropdown.hbs
@@ -1,4 +1,4 @@
-{{#md-btn-dropdown text='Button' belowOrigin="true" }}
+{{#md-btn-dropdown text='Button' belowOrigin=true}}
 	<li><a href="#!">one</a></li>
 	<li><a href="#!">two</a></li>
 	<li class="divider"></li>

--- a/tests/unit/components/materialize-button-dropdown-test.js
+++ b/tests/unit/components/materialize-button-dropdown-test.js
@@ -1,0 +1,86 @@
+import Ember from 'ember';
+import {
+  moduleForComponent,
+  test
+} from 'ember-qunit';
+
+moduleForComponent('md-btn-dropdown', 'component:md-btn-dropdown', {
+  unit: true
+  // specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar']
+});
+
+test('button dropdown renders', function(assert) {
+  assert.expect(2);
+
+  // creates the component instance
+  var component = this.subject();
+  assert.equal(component._state, 'preRender');
+
+  // appends the component to the page
+  this.render();
+  assert.equal(component._state, 'inDOM');
+});
+
+test('button dropdown is added to the page', function(assert) {
+  this.subject();
+  this.render();
+
+  assert.ok($('button').length);
+});
+
+test('dropdown shown when clicked', function(assert) {
+  var component = this.subject();
+  component.set('hover', false);
+  this.render();
+  
+  var dropdownContentId = '#' + component.get('_dropdownContentId');
+  var dropdownElement = $(dropdownContentId);
+  assert.ok(!dropdownElement.is(':visible'));
+  component.$().trigger('mouseenter');
+  assert.ok(!dropdownElement.is(':visible'));
+  component.$().click();
+  assert.ok(dropdownElement.is(':visible'));
+});
+
+test('dropdown shown when hovered', function(assert) {
+  var component = this.subject();
+  component.set('hover', true);
+  this.render();
+  
+  var dropdownContentId = '#' + component.get('_dropdownContentId');
+  var dropdownElement = $(dropdownContentId);
+  assert.ok(!dropdownElement.is(':visible'));
+  component.$().trigger('mouseenter');
+  assert.ok(dropdownElement.is(':visible'));
+});
+
+test('dropdown shown at origin', function(assert) {
+  var component = this.subject();
+  component.set('belowOrigin', false);
+  this.render();
+  
+  var dropdownContentId = '#' + component.get('_dropdownContentId');
+  var dropdownElement = $(dropdownContentId);
+  component.$().click();
+  Ember.run(function () {
+    Ember.run.schedule('afterRender', function () {
+      assert.equal(component.$().position().top + 'px', dropdownElement.css('top'));
+	});
+  });
+});
+
+test('dropdown shown below origin', function(assert) {
+  var component = this.subject();
+  component.set('belowOrigin', true);
+  this.render();
+  
+  var dropdownContentId = '#' + component.get('_dropdownContentId');
+  var dropdownElement = $(dropdownContentId);
+  component.$().click();
+  Ember.run(function () {
+    Ember.run.schedule('afterRender', function () {
+      assert.notEqual(component.$().position().top + 'px', dropdownElement.css('top'));
+	});
+  });
+});


### PR DESCRIPTION
The md-btn-dropdown component requires `'true'`/`'false'` attribute strings where it could be simply using booleans, due to the `=== 'true'` comparisons. This is also causing the `constrainWidth` default of `true` passed to `this.getWithDefault` to fail, as `true` is not `===` to `'true'`.