### PR TITLE
Allow customization of button waves

### DIFF
--- a/addon/components/md-btn.js
+++ b/addon/components/md-btn.js
@@ -7,8 +7,9 @@ const { Component, computed, computed: { oneWay }, typeOf, run: { scheduleOnce }
 export default Component.extend(UsesSettings, {
   layout,
   tagName: 'a',
-  classNameBindings: ['btn:waves-effect', 'isFlat::waves-light', 'isDisabled:disabled:waves-effect', 'buttonClass'],
+  classNameBindings: ['btn:waves-effect', 'wavesClass', 'isDisabled:disabled:waves-effect', 'buttonClass'],
   attributeBindings: ['isDisabled:disabled'],
+  wavesClass: 'waves-light',
   text: null,
   icon: null,
   iconPosition: oneWay('_mdSettings.buttonIconPosition'),

--- a/tests/dummy/app/templates/snippets/buttons-flat.hbs
+++ b/tests/dummy/app/templates/snippets/buttons-flat.hbs
@@ -11,12 +11,14 @@
 
 {{#md-btn action='debug'
 	buttonType='flat'
-	class='yellow black-text'}}
+	class='yellow black-text'
+	wavesClass='waves-dark'}}
 	Are
 {{/md-btn}}
 
 {{#md-btn action='debug'
 	buttonType='flat'
-	class='pink lighten-2 white-text'}}
+	class='pink lighten-2 white-text'
+	wavesClass='waves-dark'}}
 	Flat
 {{/md-btn}}

--- a/tests/unit/components/materialize-radios-test.js
+++ b/tests/unit/components/materialize-radios-test.js
@@ -52,19 +52,26 @@ test('deselecting checkbox works with multiple=false', function(assert) {
   });
 
   this.render(hbs `
-      {{md-radios content=content selection=selection}}
-    `);
-  const viewRegistry = Ember.View.views || Ember.View.create().get('_viewRegistry');
-  const component = viewRegistry[this.$('.md-radios')[0].id];
+    {{md-radios content=content selection=selection}}
+  `);
 
-  Ember.run(function() {
-    assert.equal(component.isValueSelected('a'), false, 'A should be un-checked');
-    assert.equal(component.isValueSelected('b'), true, 'B should be checked');
-    assert.equal(component.isValueSelected('c'), false, 'C should be un-checked');
-    assert.equal(component.get('selection'), 'b', 'Selection should be B and only B');
+  assert.equal(this.$('input:checked').length, 1, 'One item should be selected');
+  assert.equal(this.$('input:checked').attr('value'), 'b', 'Item b should be selected');
 
-    component.setValueSelection('b', false);
-    assert.equal(component.isValueSelected('b'), false, 'B should be un-checked after unselection');
-    assert.equal(component.get('selection'), null, 'Selection should be B and only B');
-  });
+  this.$('input[value="a"]').click();
+  assert.equal(this.$('input:checked').length, 1, 'One item should be selected');
+  assert.equal(this.$('input:checked').attr('value'), 'a', 'Item a should be selected');
+
+  this.$('input[value="b"]').click();
+  assert.equal(this.$('input:checked').length, 1, 'One item should be selected');
+  assert.equal(this.$('input:checked').attr('value'), 'b', 'Item b should be selected');
+
+  this.$('input[value="b"]').click();
+  assert.equal(this.$('input:checked').length, 1, 'One item should be selected');
+  assert.equal(this.$('input:checked').attr('value'), 'b', 'Item b should be selected');
+
+  this.$('input[value="c"]').click();
+  assert.equal(this.$('input:checked').length, 1, 'One item should be selected');
+  assert.equal(this.$('input:checked').attr('value'), 'c', 'Item c should be selected');
+
 });


### PR DESCRIPTION
Fixes #157 

@samselikoff I took another look, and this can easily be done while maintaining backwards compatibility.

```hbs
<!-- Implicit light waves -->
{{#md-btn action='debug'
	buttonType='flat'
	class='purple lighten-2 white-text'}}
	Buttons
{{/md-btn}}

<!-- Opt in to dark waves -->
{{#md-btn action='debug'
	buttonType='flat'
	class='yellow black-text'
	wavesClass='waves-dark'}}
	Are
{{/md-btn}}
```