### PR TITLE
Use key-responder 0.4 in the blueprint as well

### DIFF
--- a/blueprints/ember-cli-materialize/index.js
+++ b/blueprints/ember-cli-materialize/index.js
@@ -12,7 +12,7 @@ module.exports = {
       this.addPackageToProject('ember-composability', '~0.1.1'),
       this.addPackageToProject('ember-radio-button', '1.0.7'),
       this.addPackageToProject('ember-new-computed', '~1.0.0'),
-      this.addPackageToProject('ember-key-responder', '0.2.1'),
+      this.addPackageToProject('ember-key-responder', '~0.4.0'),
       this.addPackageToProject('ember-modal-dialog', '~0.7.5'),
       this.addPackageToProject('ember-cli-sass', '^3.3.0'),
       this.addPackageToProject('ember-legacy-views', '^0.2.0')


### PR DESCRIPTION
Updating the dependency here to match package.json.

#191 updated the `ember-key-responder` version in package.json, but this version from the blueprint is used when I installed this as a addon in my project.