### PR TITLE
Fixed dropdown constrain_width property

### DIFF
--- a/addon/components/md-btn-dropdown.js
+++ b/addon/components/md-btn-dropdown.js
@@ -25,6 +25,7 @@ export default MaterializeButton.extend({
 
     this.$().dropdown({
       hover: !!this.getWithDefault('hover', false),
+      // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
       constrain_width: !!this.getWithDefault('constrainWidth', true),
       inDuration: this.getWithDefault('inDuration', this.get('_mdSettings.dropdownInDuration')),
       outDuration: this.getWithDefault('outDuration', this.get('_mdSettings.dropdownOutDuration')),

--- a/addon/components/md-btn-dropdown.js
+++ b/addon/components/md-btn-dropdown.js
@@ -27,6 +27,7 @@ export default MaterializeButton.extend({
       hover: !!this.getWithDefault('hover', false),
       // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
       constrain_width: !!this.getWithDefault('constrainWidth', true),
+      // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
       inDuration: this.getWithDefault('inDuration', this.get('_mdSettings.dropdownInDuration')),
       outDuration: this.getWithDefault('outDuration', this.get('_mdSettings.dropdownOutDuration')),
       gutter: this.getWithDefault('gutter', 0),

--- a/addon/components/md-btn-dropdown.js
+++ b/addon/components/md-btn-dropdown.js
@@ -25,7 +25,7 @@ export default MaterializeButton.extend({
 
     this.$().dropdown({
       hover: !!this.getWithDefault('hover', false),
-      constrainWidth: !!this.getWithDefault('constrainWidth', true),
+      constrain_width: !!this.getWithDefault('constrainWidth', true),
       inDuration: this.getWithDefault('inDuration', this.get('_mdSettings.dropdownInDuration')),
       outDuration: this.getWithDefault('outDuration', this.get('_mdSettings.dropdownOutDuration')),
       gutter: this.getWithDefault('gutter', 0),

--- a/tests/unit/components/materialize-button-dropdown-test.js
+++ b/tests/unit/components/materialize-button-dropdown-test.js
@@ -84,3 +84,33 @@ test('dropdown shown below origin', function(assert) {
     });
   });
 });
+
+test('dropdown with constrained width', function(assert) {
+  const component = this.subject();
+  component.set('constrainWidth', true);
+  this.render();
+
+  const dropdownContentId = `#${component.get('_dropdownContentId')}`;
+  const dropdownElement = $(dropdownContentId);
+  component.$().click();
+  Ember.run(function() {
+    Ember.run.schedule('afterRender', function() {
+      assert.equal(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
+    });
+  });
+});
+
+test('dropdown with unconstrained width', function(assert) {
+  const component = this.subject();
+  component.set('constrainWidth', false);
+  this.render();
+
+  const dropdownContentId = `#${component.get('_dropdownContentId')}`;
+  const dropdownElement = $(dropdownContentId);
+  component.$().click();
+  Ember.run(function() {
+    Ember.run.schedule('afterRender', function() {
+      assert.notEqual(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
+    });
+  });
+});

--- a/tests/unit/components/materialize-button-dropdown-test.js
+++ b/tests/unit/components/materialize-button-dropdown-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import {
   moduleForComponent,
   test
@@ -63,11 +62,7 @@ test('dropdown shown at origin', function(assert) {
   const dropdownContentId = `#${component.get('_dropdownContentId')}`;
   const dropdownElement = $(dropdownContentId);
   component.$().click();
-  Ember.run(function() {
-    Ember.run.schedule('afterRender', function() {
-      assert.equal(`${component.$().position().top}px`, dropdownElement.css('top'));
-    });
-  });
+  assert.equal(`${component.$().position().top}px`, dropdownElement.css('top'));
 });
 
 test('dropdown shown below origin', function(assert) {
@@ -78,11 +73,7 @@ test('dropdown shown below origin', function(assert) {
   const dropdownContentId = `#${component.get('_dropdownContentId')}`;
   const dropdownElement = $(dropdownContentId);
   component.$().click();
-  Ember.run(function() {
-    Ember.run.schedule('afterRender', function() {
-      assert.notEqual(`${component.$().position().top}px`, dropdownElement.css('top'));
-    });
-  });
+  assert.notEqual(`${component.$().position().top}px`, dropdownElement.css('top'));
 });
 
 test('dropdown with constrained width', function(assert) {
@@ -93,11 +84,7 @@ test('dropdown with constrained width', function(assert) {
   const dropdownContentId = `#${component.get('_dropdownContentId')}`;
   const dropdownElement = $(dropdownContentId);
   component.$().click();
-  Ember.run(function() {
-    Ember.run.schedule('afterRender', function() {
-      assert.equal(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
-    });
-  });
+  assert.equal(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
 });
 
 test('dropdown with unconstrained width', function(assert) {
@@ -108,9 +95,5 @@ test('dropdown with unconstrained width', function(assert) {
   const dropdownContentId = `#${component.get('_dropdownContentId')}`;
   const dropdownElement = $(dropdownContentId);
   component.$().click();
-  Ember.run(function() {
-    Ember.run.schedule('afterRender', function() {
-      assert.notEqual(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
-    });
-  });
+  assert.notEqual(`${component.$().outerWidth()}px`, dropdownElement.css('width'));
 });


### PR DESCRIPTION
In properties passed to Materialize jquery `dropdown` plugin, `constrainWidth` should actually be named `constrain_width`. See https://github.com/Dogfalo/materialize/blob/master/js/dropdown.js