### PR TITLE
Added support for placeholder attribute to md-input

### DIFF
--- a/addon/templates/components/md-input.hbs
+++ b/addon/templates/components/md-input.hbs
@@ -15,7 +15,8 @@
   autofocus=autofocus
   step=step
   min=min
-  max=max}}
+  max=max
+  placeholder=placeholder}}}}
 <label for="{{id}}">{{label}}</label>
 
 <small class="red-text">


### PR DESCRIPTION
As the placeholder attribute is supported by materializecss I added support fro passing along that attribute to the ember md-input component.