### PR TITLE
Add md-btn-to as link-to button replacement

### DIFF
--- a/addon/components/md-btn-to.js
+++ b/addon/components/md-btn-to.js
@@ -1,0 +1,8 @@
+import MaterializeButton from './md-btn';
+
+export default MaterializeButton.extend({
+  layoutName: 'components/materialize-button',
+  tagName: 'button',
+  attributeBindings: ['type'],
+  type: 'submit'
+});

--- a/app/components/md-btn-to.js
+++ b/app/components/md-btn-to.js
@@ -1,0 +1,3 @@
+import MaterializeButtonTo from 'ember-cli-materialize/components/md-btn-to';
+
+export default MaterializeButtonTo;


### PR DESCRIPTION
This is a long running PR to track progress on making an `md-btn-to` component.

From my personal opinion and tracking issues and proposals on this repo I think we should have the following to-dos:

* [ ] Wait for materialize button animation to finish before starting transition

I hope to get to actually working on this tomorrow during the day/afternoon.