### PR TITLE
Overlay content on parallax image.

### DIFF
--- a/addon/templates/components/md-parallax.hbs
+++ b/addon/templates/components/md-parallax.hbs
@@ -1,3 +1,4 @@
+{{yield}}
 <div class="parallax">
   <img src="{{image}}"/>
 </div>


### PR DESCRIPTION
Allows you to overlay content on top of the image, like in the demo:
http://materializecss.com/templates/parallax-template/preview.html

### Usage

```
{{#md-parallax image="http://materializecss.com/templates/parallax-template/background2.jpg"}}
<div class="section no-pad-bot">
  <div class="container">
    <br><br>
    <h1 class="header center teal-text text-lighten-2">Parallax Template</h1>
    <div class="row center">
      <h5 class="header col s12 light">A modern responsive front-end framework based on Material Design</h5>
    </div>
    <div class="row center">
      <a href="http://materializecss.com/getting-started.html" id="download-button" class="btn-large waves-effect waves-light teal lighten-1">Get Started</a>
    </div>
    <br><br>
  </div>
</div>
{{/md-parallax}}
```
