### PR TITLE
#275 - refactor initializers to squash initializer arity deprecation

### DIFF
--- a/app/initializers/add-modals-container.js
+++ b/app/initializers/add-modals-container.js
@@ -1,4 +1,6 @@
-export function initialize (container, application){
+export function initialize (){
+  let application = arguments[1] || arguments[0];
+
   var rootEl = document.querySelector(application.rootElement);
   var modalContainerEl = document.createElement('div');
   var emberModalDialog = application.emberModalDialog || {};

--- a/app/initializers/md-settings.js
+++ b/app/initializers/md-settings.js
@@ -1,8 +1,9 @@
 import config from '../config/environment';
 import MaterializeSettings from 'ember-cli-materialize/services/md-settings';
 
-export function initialize(container, application) {
+export function initialize() {
   const { materializeDefaults } = config;
+  let application = arguments[1] || arguments[0];
 
   application.register('config:materialize', materializeDefaults, { instantiate: false });
   application.register('service:materialize-settings', MaterializeSettings);


### PR DESCRIPTION
PR to address the ember 2.1 initializer arity deprecations when running ember 2.1+