### PR TITLE
Added doc for isFooterFixed attr on modals

### DIFF
--- a/tests/dummy/app/templates/modal.hbs
+++ b/tests/dummy/app/templates/modal.hbs
@@ -3,6 +3,7 @@
 <div class='container'>
   {{#options-panel}}
     {{component-option optionId="close" default="close" description="action called by hitting 'esc' key or clicking on overlay"}}
+    {{component-option optionId="isFooterFixed" default="false" description="toggle to add a fixed footer to your modal"}}
   {{/options-panel}}
 
 


### PR DESCRIPTION
Thought adding some documentation for this property would be helpful - I had to go digging in the source to find how to set the footer of a particular modal to fixed.