### PR TITLE
Icon fixes for all components

### DIFF
--- a/addon/templates/components/md-btn-dropdown.hbs
+++ b/addon/templates/components/md-btn-dropdown.hbs
@@ -1,5 +1,5 @@
 {{#if icon}}
- <i class="material-icons {{iconPosition}}">{{icon}}</i>
+ <i class="material-icons {{iconPosition}}">{{icon}}</i> 
 {{/if}}
 {{text}}
 <ul id="{{_dropdownContentId}}" class="dropdown-content">

--- a/addon/templates/components/md-btn.hbs
+++ b/addon/templates/components/md-btn.hbs
@@ -1,5 +1,5 @@
 {{#if icon}}
-  <i class="{{icon}} {{iconPosition}}"></i>
+  <i class="{{icon}} {{iconPosition}}"></i> 
 {{/if}}
 {{text}}
 {{yield}}

--- a/addon/templates/components/md-card-content.hbs
+++ b/addon/templates/components/md-card-content.hbs
@@ -3,7 +3,7 @@
     {{title}}
 
     {{#if activator}}
-      <i class="material-icons right">more-vert</i>
+      <i class="material-icons right">more_vert</i>
     {{/if}}
   </span>
 {{/if}}

--- a/addon/templates/components/md-card-reveal.hbs
+++ b/addon/templates/components/md-card-reveal.hbs
@@ -1,4 +1,4 @@
 <span class="card-title grey-text text-darken-4 {{if activator 'activator'}}">
-  {{parentView.title}} <i class="material-icons right">close</i>
+  {{parentView.title}} <i class="material-icons right">close</i> 
 </span>
 <p>{{yield}}</p>

--- a/addon/templates/components/md-collapsible.hbs
+++ b/addon/templates/components/md-collapsible.hbs
@@ -1,6 +1,6 @@
 <div class="collapsible-header {{if active 'active'}}" {{action "headerClicked"}}>
   {{#if icon}}
-    <i class="material-icons left">{{icon}}</i>
+    <i class="material-icons left">{{icon}}</i> 
   {{/if}}
 
   {{title}}

--- a/addon/templates/components/md-input-date.hbs
+++ b/addon/templates/components/md-input-date.hbs
@@ -1,5 +1,5 @@
 {{#if icon}}
-  <i class="material-icons left prefix">{{icon}}</i>
+  <i class="material-icons left prefix">{{icon}}</i> 
 {{/if}}
 
 <input type="date"

--- a/addon/templates/components/md-input.hbs
+++ b/addon/templates/components/md-input.hbs
@@ -1,5 +1,5 @@
 {{#if icon}}
-  <i class="{{icon}} prefix"></i>
+  <i class="material-icons left prefix">{{icon}}</i>
 {{/if}}
 
 {{input id=id

--- a/addon/templates/components/md-pagination.hbs
+++ b/addon/templates/components/md-pagination.hbs
@@ -1,6 +1,6 @@
 <li class="{{decrementClass}}">
   <a {{action 'oneBack'}}  class='decrement'>
-    <i class="material-icons right">chevron_left</i>
+    <i class="material-icons right">chevron_left</i> 
   </a>
 </li>
 
@@ -14,6 +14,6 @@
 
 <li class="{{incrementClass}}">
   <a {{action 'oneFwd'}}  class='increment'>
-    <i class="material-icons left">chevron_right</i>
+    <i class="material-icons left">chevron_right</i> 
   </a>
 </li>

--- a/addon/templates/components/md-textarea.hbs
+++ b/addon/templates/components/md-textarea.hbs
@@ -1,5 +1,5 @@
 {{#if icon}}
-  <i class="{{icon}} prefix"></i>
+  <i class="material-icons left prefix">{{icon}}</i>
 {{/if}}
 
 {{textarea id=id value=value name=name required=required readonly=readonly disabled=disabled maxlength=maxlength class="materialize-textarea"}}

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-keyboard": "^1.0.3",
     "ember-load-initializers": "^0.5.1",
     "ember-material-design-icons-shim": "0.1.3",
-    "ember-materialize-shim": "0.1.3",
+    "ember-materialize-shim": "0.1.4",
     "ember-modal-dialog": "~0.8.0",
     "ember-new-computed": "~1.0.2",
     "ember-radio-button": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ember-cli-materialize",
   "description": "An ember-cli addon for using Materialize (CSS Framework based on Material Design) in Ember applications.",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "directories": {
     "doc": "doc",
     "test": "tests"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "2.0.1",
+    "ember-ajax": "2.1.0",
     "ember-anchor": "~0.1.2",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "ember-keyboard": "^1.0.3",
     "ember-load-initializers": "^0.5.1",
     "ember-material-design-icons-shim": "0.1.0",
-    "ember-materialize-shim": "0.1.0",
+    "ember-materialize-shim": "0.1.3",
     "ember-modal-dialog": "~0.8.0",
     "ember-new-computed": "~1.0.2",
     "ember-radio-button": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-keyboard": "^1.0.3",
     "ember-load-initializers": "^0.5.1",
-    "ember-material-design-icons-shim": "0.1.0",
+    "ember-material-design-icons-shim": "0.1.2",
     "ember-materialize-shim": "0.1.3",
     "ember-modal-dialog": "~0.8.0",
     "ember-new-computed": "~1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-keyboard": "^1.0.3",
     "ember-load-initializers": "^0.5.1",
-    "ember-material-design-icons-shim": "0.1.2",
+    "ember-material-design-icons-shim": "0.1.3",
     "ember-materialize-shim": "0.1.3",
     "ember-modal-dialog": "~0.8.0",
     "ember-new-computed": "~1.0.2",


### PR DESCRIPTION
I added to all components wich uses icons the 'material-icon' class. 

example before:

> {{md-btn text='Button'
>     **icon='mdi-image-filter-drama'**
>     iconPosition='right'
>     action='debug'
>     class='deep-orange darken-3'}}

now:

> {{md-btn text='Button'
>     **icon='filter_drama'**
>     iconPosition='right'
>     action='debug'
>     class='deep-orange darken-3'}}

@mike-north sorry for that many commits, I made a mistake at the beginning