### PR TITLE
Update to latest ember-cli-sass to avoid deprecation warnings on node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-qunit": "^2.0.0",
     "ember-cli-release": "1.0.0-beta.1",
-    "ember-cli-sass": "mike-north/ember-cli-sass#8ceb57d41f5774e8ececb5d1f05454449c19000c",
+    "ember-cli-sass": "5.3.1",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-cli-version-checker": "^1.1.6",


### PR DESCRIPTION
- Indirectly, the latest version of upstream ember-cli-sass has newer version of node-sass which avoids a deprecation warning