### PR TITLE
update components to use material design icon font

### DIFF
--- a/addon/templates/components/md-card-content.hbs
+++ b/addon/templates/components/md-card-content.hbs
@@ -3,7 +3,7 @@
     {{title}}
 
     {{#if activator}}
-      <i class="mdi-navigation-more-vert right"></i>
+      <i class="material-icons right">more_vert</i>
     {{/if}}
   </span>
 {{/if}}

--- a/addon/templates/components/md-card-reveal.hbs
+++ b/addon/templates/components/md-card-reveal.hbs
@@ -1,4 +1,4 @@
 <span class="card-title grey-text text-darken-4 {{if activator 'activator'}}">
-  {{parentView.title}} <i class="mdi-navigation-close right"></i>
+  {{parentView.title}} <i class="material-icons right">close</i>
 </span>
 <p>{{yield}}</p>

--- a/addon/templates/components/md-pagination.hbs
+++ b/addon/templates/components/md-pagination.hbs
@@ -1,6 +1,6 @@
 <li class="{{decrementClass}}">
   <a {{action 'oneBack'}}  class='decrement'>
-    <i class="mdi-navigation-chevron-left"></i>
+    <i class="material-icons">chevron_left</i>
   </a>
 </li>
 
@@ -14,6 +14,6 @@
 
 <li class="{{incrementClass}}">
   <a {{action 'oneFwd'}}  class='increment'>
-    <i class="mdi-navigation-chevron-right"></i>
+    <i class="material-icons">chevron_right</i>
   </a>
 </li>

--- a/tests/integration/cards-test.js
+++ b/tests/integration/cards-test.js
@@ -22,7 +22,7 @@ function checkCardTitle(cardType, cardId) {
       const titleEle = find(`#${cardId} > .card-content span`);
 
       assert.ok(titleEle.hasClass('card-title'));
-      assert.equal(titleEle.text().trim(), 'Card Title');
+      assert.equal(titleEle.children().remove().end().text().trim(), 'Card Title');
     });
   });
 }


### PR DESCRIPTION
Icons are not displaying from within card and pagination components since materialize was updated to use 'Material Icons' font. 