### PR TITLE
Upgrade ember-materialize-shim to 0.2.2

### DIFF
--- a/blueprints/ember-cli-materialize/index.js
+++ b/blueprints/ember-cli-materialize/index.js
@@ -7,7 +7,7 @@ module.exports = {
   normalizeEntityName: function() {},
   afterInstall: function(options) {
     return this.addAddonsToProject({packages: [
-      {name: 'ember-materialize-shim', target: '~0.1.5'},
+      {name: 'ember-materialize-shim', target: '~0.2.2'},
       {name: 'ember-truth-helpers', target: '^1.2.0'},
       {name: 'ember-composable-helpers', target: '~0.19.0'},
       {name: 'ember-cli-flash', target: '^1.3.14'},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "ember-inflector": "1.9.4",
     "ember-load-initializers": "^0.5.1",
     "ember-material-design-icons-shim": "0.1.9",
-    "ember-materialize-shim": "0.2.1",
+    "ember-materialize-shim": "0.2.2",
     "ember-modal-dialog": "~0.8.3",
     "ember-pikaday": "1.0.0",
     "ember-resolver": "^2.0.3",
@@ -77,7 +77,7 @@
     "ember-cli-sass": "5.3.1",
     "ember-truth-helpers": "^1.2.0",
     "ember-composable-helpers": "0.27.0",
-    "ember-materialize-shim": "^0.2.0",
+    "ember-materialize-shim": "^0.2.2",
     "rsvp": "^3.2.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Primary motivation is to bump the version in the addon blueprint.