### PR TITLE
[v1] Move some dependencies to package.json

### DIFF
--- a/blueprints/ember-cli-materialize/index.js
+++ b/blueprints/ember-cli-materialize/index.js
@@ -8,11 +8,8 @@ module.exports = {
   afterInstall: function(options) {
     return this.addAddonsToProject({packages: [
       {name: 'ember-materialize-shim', target: '~0.1.5'},
-      {name: 'ember-truth-helpers', target: '^1.2.0'},
-      {name: 'ember-composable-helpers', target: '~0.19.0'},
       {name: 'ember-cli-flash', target: '^1.3.14'},
-      {name: 'ember-gestures',  target:'~0.4.1'},
-      {name: 'ember-modal-dialog', target: '~0.8.3'}
+      {name: 'ember-gestures',  target:'~0.4.1'}
     ]});
   }
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-material-design-icons-shim": "0.1.9",
     "ember-materialize-shim": "0.2.2",
-    "ember-modal-dialog": "~0.8.3",
+    "ember-modal-dialog": "^0.8.8",
     "ember-pikaday": "1.0.0",
     "ember-resolver": "^2.0.3",
     "ember-sublime": "^0.0.9",
@@ -77,8 +77,8 @@
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.5",
     "ember-cli-sass": "5.3.1",
+    "ember-composable-helpers": "^1.0.0",
     "ember-truth-helpers": "^1.2.0",
-    "ember-composable-helpers": "0.27.0",
     "rsvp": "^3.2.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Packages without a blueprint do not need to be inserted into the end-user's project.

- ember-composable-helpers (also upgraded to 1.0.0)
- ember-modal-dialog (also upgraded to 0.8.8)
- ember-truth-helpers

Closes #404 