### PR TITLE
Use optionLabelPath with empty optionValuePath

### DIFF
--- a/addon/components/selectable-item-group.js
+++ b/addon/components/selectable-item-group.js
@@ -72,18 +72,13 @@ export default Component.extend(ParentComponentSupport, {
     const labelPath = get(this, '_labelPath');
     const content = get(this, 'content') || new A([]);
 
-    if (valuePath && labelPath) {
-      return A(
-        content.map(el => {
-          return { value: get(el, valuePath), label: get(el, labelPath) };
-        })
-      );
-    } else {
-      return A(
-        content.map(el => {
-          return { value: el, label: el };
-        })
-      );
-    }
+    return A(
+      content.map(el => {
+        return {
+          value: valuePath ? get(el, valuePath) : el,
+          label: labelPath ? get(el, labelPath) : el
+        };
+      })
+    );
   })
 });

--- a/app/components/selectable-item-group.js
+++ b/app/components/selectable-item-group.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cli-materialize/components/selectable-item-group';

--- a/tests/unit/components/selectable-item-group-test.js
+++ b/tests/unit/components/selectable-item-group-test.js
@@ -1,0 +1,53 @@
+import { moduleForComponent, test } from 'ember-qunit';
+
+moduleForComponent('selectable-item-group', 'Unit | Component | selectable item group', {
+  // Specify the other units that are required for this test
+  // needs: ['component:foo', 'helper:bar'],
+  unit: true
+});
+
+test('it uses the expected optionValuePath and optionLabelPath', function(assert) {
+  let collection;
+  let component = this.subject();
+
+  assert.expect(7);
+
+  // unset every one of them
+  collection = [1, 2, 3];
+
+  component.set('content', collection);
+
+  assert.ok(
+    component.get('_content').every(
+      (elem, i) => {
+        return elem.value === collection[i] &&
+          elem.label === collection[i];
+      }
+    )
+  );
+
+  collection = [
+    {
+      id: 1,
+      name: 'Jack Shepard'
+    },
+    {
+      id: 2,
+      name: 'Hugo Reyes'
+    },
+    {
+      id: 3,
+      name: 'John Locke'
+    }
+  ];
+
+  component.set('optionLabelPath', 'content.name');
+  component.set('content', collection);
+
+  component.get('_content').forEach(
+    (option, i) => {
+      assert.equal(option.label, collection[i].name);
+      assert.deepEqual(option.value, collection[i]);
+    }
+  );
+});


### PR DESCRIPTION
It allows the component select-item-group to use custom optionLabelPath
when optionValuePath is empty or "content".

Close #441