### PR TITLE
Add 'popout' functionality to collapsible sections

### DIFF
--- a/addon/components/md-card-collapsible.js
+++ b/addon/components/md-card-collapsible.js
@@ -6,9 +6,10 @@ const { computed, Component } = Ember;
 export default Component.extend({
   layout,
   tagName: 'ul',
-  classNames: ['collapsible'],
+  classNames: ['collapsible', 'popout'],
   attributeBindings: ['data-collapsible'],
   accordion: true,
+  popout: false,
 
   'data-collapsible': computed(function() {
     return this.get('accordion') ? 'accordion' : 'expandable';


### PR DESCRIPTION
MaterializeCSS has built-in support for a 'popout class that allows for a more flashy open/close animation.

Underlying support for this option is already available, we must only expose an API to modify this property on the md-card-collapsible component.
