### PR TITLE
Add null option for md-select

### DIFF
--- a/addon/templates/components/md-select.hbs
+++ b/addon/templates/components/md-select.hbs
@@ -4,7 +4,7 @@
         class="{{if validate 'validate'}} {{if errors 'invalid' 'valid'}}"
         disabled={{if disabled "true"}}>
   {{#if prompt}}
-    <option value="" disabled selected={{unless value "true"}}>{{prompt}}</option>
+    <option value="" disabled={{unless withNullOption "true"}} selected={{unless value "true"}}>{{prompt}}</option>
   {{/if}}
   {{#each _parsedContent as |option|}}
     <option value={{option.value}} selected={{if (eq value option.value) "true"}}>{{option.label}}</option>


### PR DESCRIPTION
You can pass a new attribute to the components md-select called withNullOption
(I don't know if it's the best name for the parameter) and this option would allow
that the prompt can be also a enabled option. This null option it's useful when you
want to clear a <select> and you don't want to force the user to mark one of the
available options.

Clases #536 