### PR TITLE
on window resize, change the tab indicator size

### DIFF
--- a/addon/components/md-tabs.js
+++ b/addon/components/md-tabs.js
@@ -29,7 +29,9 @@ export default Component.extend(ParentComponentSupport, {
 
   didInsertElement() {
     this._super(...arguments);
-    this._updateIndicatorPosition(false);
+    this.$(window).resize(() => {
+      this._updateIndicatorPosition(false);
+    });
   },
 
   _indicatorUpdater: observer('selected', 'content.[]', 'composableChildren.[]', function() {


### PR DESCRIPTION
initiate a resize event so that indicators update when the window resizes. Fixes situations like this: 
<img width="520" alt="screen shot on 2017-03-08 at 16-13-57" src="https://cloud.githubusercontent.com/assets/8890675/23730062/4dad2588-041a-11e7-9f5e-06f2440cabd9.png">
