### PR TITLE
FastBoot compatibility for md-navbar component

### DIFF
--- a/addon/components/md-navbar.js
+++ b/addon/components/md-navbar.js
@@ -26,7 +26,7 @@ export default Component.extend({
   },
 
   _sideNavId: computed(function() {
-    return `${this.get('element.id')}-sidenav`;
+    return (typeof FastBoot === 'undefined') ? `${this.get('element.id')}-sidenav` : '';
   })
 
   // TODO: Unregister any listeners that $.sideNav() puts in place


### PR DESCRIPTION
Only access `this.element` when running in the browser.