### PR TITLE
feat: multiple should check for undef too

### DIFF
--- a/addon/components/selectable-item-group.js
+++ b/addon/components/selectable-item-group.js
@@ -17,7 +17,7 @@ export default Component.extend(ParentComponentSupport, {
 
   init() {
     this._super(...arguments);
-    if (this.get('selection') === null && !!this.get('multiple')) {
+    if ((this.get('selection') === null || this.get('selection') === undefined) && !!this.get('multiple')) {
       this.set('selection', new A([]));
     }
   },


### PR DESCRIPTION
We need to check for `undefined` as well as `null`.