### PR TITLE
feat: if the date picker is cleared then the value should be nulled

### DIFF
--- a/addon/components/md-input-date.js
+++ b/addon/components/md-input-date.js
@@ -47,6 +47,8 @@ export default MaterializeInput.extend({
     this._onDateSet = evt => {
       if (evt.select) {
         this.set('value', formatDate(evt.select));
+      } else {
+        this.set('value', null);
       }
     };
 


### PR DESCRIPTION
If you click the "Clear" button this sets the UI to empty. However this test doesn't allow that to be passed through. This fixes that situation.